### PR TITLE
feat: handle url paths that ends with :

### DIFF
--- a/pipeline/frames/main.py
+++ b/pipeline/frames/main.py
@@ -60,7 +60,7 @@ async def main(daemon: bool):
     logger.info(f"Sample rows: {sample(url_records, min(5, len(url_records)))}")
 
     if len(url_records) > 0:
-      http_timeout = aiohttp.ClientTimeout(sock_connect=settings.FRAMES_SCRAPE_CONNECT_TIMEOUT_SECS, 
+      http_timeout = aiohttp.ClientTimeout(sock_connect=settings.FRAMES_SCRAPE_CONNECT_TIMEOUT_SECS,
                                            sock_read=settings.FRAMES_SCRAPE_READ_TIMEOUT_SECS)
       connector = aiohttp.TCPConnector(ttl_dns_cache=3000, limit=settings.FRAMES_SCRAPE_CONCURRENCY)
       http_conn_pool = aiohttp.ClientSession(connector=connector)
@@ -101,7 +101,7 @@ if __name__ == "__main__":
                    help="set or not",
                    default=False,
                    type=lambda x: (str(x).lower() == 'true'))
-  
+
   args = parser.parse_args()
   print(args)
 

--- a/pipeline/frames/scrape_utils.py
+++ b/pipeline/frames/scrape_utils.py
@@ -16,8 +16,8 @@ class URLCategory(Enum):
   ERROR = 'error'
 
 async def categorize_url(
-    logger: logging.Logger, 
-    url_id: int, url:str, 
+    logger: logging.Logger,
+    url_id: int, url:str,
     session: aiohttp.ClientSession,
     timeout: aiohttp.ClientTimeout
 ) -> tuple[int, str]:
@@ -25,7 +25,7 @@ async def categorize_url(
   if urlparse(url).scheme not in ['http','https']:
     logger.error(f"bad url {url_id} - {url}")
     return (url_id, URLCategory.BAD.value)
-      
+
   try:
     async with session.get(url, timeout=timeout) as resp:
       body = await resp.text()
@@ -45,7 +45,7 @@ async def categorize_url(
   except Exception as e:
     logger.error(f"error {url_id} - {url}: {e}")
     return (url_id, URLCategory.ERROR.value)
-  
+
 class URL_parts(NamedTuple):
   url_id: int
   scheme: str
@@ -55,17 +55,20 @@ class URL_parts(NamedTuple):
   path: str
 
 def parse_url(
-    logger: logging.Logger, 
-    url_id: int, 
+    logger: logging.Logger,
+    url_id: int,
     url:str
 ) -> tuple[int, str, str, str, str, str]:
   logger.debug(f"parsing {url_id} - {url}")
   parse_result = urlparse(url)
   extract = tldextract.extract(url)
-  return tuple(URL_parts(url_id, 
+  path = parse_result.path
+  if path.endswith(':'):
+    path = path[:-1]
+  return tuple(URL_parts(url_id,
                    parse_result.scheme,
-                   extract.domain, 
+                   extract.domain,
                    extract.subdomain,
                    extract.suffix,
-                   parse_result.path))
+                   path))
 


### PR DESCRIPTION
This error was pretty common. This should fix the problem for now 
```
[2024-07-10, 15:55:11 HST] {subprocess.py:93} INFO - 2024-07-11 01:55:11 | main:main.py:main:60 | INFO | Sample rows: [(3163367, '[https://moxie-frames.airstack.xyz/ca1e?u=543570&w=0xe48129bdca6f2520cf25cffa5cb52933c66cd38b'),](https://moxie-frames.airstack.xyz/ca1e?u=543570&w=0xe48129bdca6f2520cf25cffa5cb52933c66cd38b%27),) (3163247, '[https://compez.art/farcaster/superrare/view/allowance?fid=553423/1720660645'),](https://compez.art/farcaster/superrare/view/allowance?fid=553423/1720660645%27),) (3163319, '[https://maps.app.goo.gl/M61esYGx1sHTorBR7'),](https://maps.app.goo.gl/M61esYGx1sHTorBR7%27),) (3163373, '[https://moxie-frames.airstack.xyz/mpi?k=251993-fuMZ2Qqt8CYhpU8JWrpwG'),](https://moxie-frames.airstack.xyz/mpi?k=251993-fuMZ2Qqt8CYhpU8JWrpwG%27),) (3163433, '[https://www.tacosloteria.com/')]](https://www.tacosloteria.com/%27)]%3C/span%3E)
[2024-07-10, 15:55:12 HST] {subprocess.py:93} INFO - Start a new timer: categorize_url
[2024-07-10, 15:55:12 HST] {subprocess.py:93} INFO - 2024-07-11 01:55:12 | scrape_utils:scrape_utils.py:categorize_url:46 | ERROR | error 3163289 - https://ik.imagekit.io/lens/media-snapshot/391ca69adec1031517de41f74ca05cb29b28830ef1dfec2ce7da75d36cf789fe.webp: 'utf-8' codec can't decode byte 0xff in position 0: invalid start byte
[2024-07-10, 15:55:12 HST] {subprocess.py:93} INFO - 2024-07-11 01:55:12 | scrape_utils:scrape_utils.py:categorize_url:43 | ERROR | error 3163208 - [http://howtohandlefame.com:](http://howtohandlefame.com/) Cannot connect to host howtohandlefame.com:80 ssl:default [Name or service not known]
[2024-07-10, 15:55:14 HST] {subprocess.py:93} INFO - 2024-07-11 01:55:14 | scrape_utils:scrape_utils.py:categorize_url:46 | ERROR | error 3163291 - https://images.lens.phaver.com/insecure/raw:t/plain/3e2111b52c64f6ec209743047559a157: 'utf-8' codec can't decode byte 0xff in position 0: invalid start byte
[2024-07-10, 15:55:15 HST] {subprocess.py:93} INFO - 2024-07-11 01:55:15 | scrape_utils:scrape_utils.py:categorize_url:46 | ERROR | error 3163290 - https://ik.imagekit.io/lens/media-snapshot/cca329dd2fa734f4a9ea4a6bc8c17cba937c2d68150ebfaae3a806745bd6b4b7.webp: 'utf-8' codec can't decode byte 0xff in position 0: invalid start byte
[2024-07-10, 15:55:15 HST] {subprocess.py:93} INFO - 2024-07-11 01:55:15 | scrape_utils:scrape_utils.py:categorize_url:46 | ERROR | error 3163390 - https://rocket.metastreet.xyz/api/result/1720662265/1720662325: 'utf-8' codec can't decode byte 0x89 in position 0: invalid start byte
[2024-07-10, 15:55:16 HST] {subprocess.py:93} INFO - 2024-07-11 01:55:16 | scrape_utils:scrape_utils.py:categorize_url:46 | ERROR | error 3163391 - https://rocket.metastreet.xyz/api/result/1720662529/1720662585: 'utf-8' codec can't decode byte 0x89 in position 0: invalid start byte
[2024-07-10, 15:55:19 HST] {subprocess.py:93} INFO - 2024-07-11 01:55:19 | scrape_utils:scrape_utils.py:categorize_url:46 | ERROR | error 3163384 - https://ploink.fun/api/assets/reactionembed/210: 'utf-8' codec can't decode byte 0x89 in position 0: invalid start byte
```