### PR TITLE
feat: allow extra env variable

### DIFF
--- a/pipeline/config.py
+++ b/pipeline/config.py
@@ -58,7 +58,8 @@ class Settings(BaseSettings):
 
     model_config = SettingsConfigDict(
         # `.env.prod` takes priority over `.env`
-        env_file=('.env', '.env.prod')
+        env_file=('.env', '.env.prod'),
+        extra="allow"  # Allow extra environment variables
     )
 
     @computed_field

--- a/serve/app/config.py
+++ b/serve/app/config.py
@@ -32,7 +32,8 @@ class Settings(BaseSettings):
 
     model_config = SettingsConfigDict(
         # `.env.prod` takes priority over `.env`
-        env_file=('.env', '.env.prod')
+        env_file=('.env', '.env.prod'),
+        extra="allow"  # Allow extra environment variables
     )
 
     @computed_field


### PR DESCRIPTION
I added this PR to allow extra environmental variable. 

Currently, when you introduce a new envvar, and you switch to other branch, the program will fail since .env will still have the new envvar that is not on the other branch.

Previously, this caused outrage, and I think it's doing more harm than good.
