### PR TITLE
fix: /channels/casts/daily/{channel}

### DIFF
--- a/serve/app/routers/channel_router.py
+++ b/serve/app/routers/channel_router.py
@@ -545,6 +545,7 @@ async def get_trending_casts(
         max_cast_age=f"{max_cast_age} days",
         agg=agg,
         score_threshold=0.000000001,
+        cutoff_ptile=100,
         weights=weights,
         shuffle=False,
         time_decay=time_decay,


### PR DESCRIPTION
Commit 7cae27df0b13a7775efdd6ddc2d04f29cc1e6e5b introduced cutoff_ptile to `db_utils.get_trending_channel_casts_heavy()` but missed adding it to one call site.  This commit substitutes the default value.