### PR TITLE
feat: make /personalized/popular/{fid} support explicit channels

### DIFF
--- a/serve/app/models/feed_model.py
+++ b/serve/app/models/feed_model.py
@@ -60,6 +60,7 @@ class TrendingFeed(BaseModel):
     shuffle: bool = False
     timeout_secs: Annotated[int, Field(alias="timeoutSecs", ge=3, le=30)] = settings.FEED_TIMEOUT_SECS
     session_id: Annotated[str, Field(alias="sessionId")] = None
+    channels: Annotate[list[str], Field(alias="channels")] = None
 
 class PopularFeed(BaseModel):
     feed_type: Annotated[Literal['popular'], Field(alias="feedType")]
@@ -73,6 +74,7 @@ class PopularFeed(BaseModel):
     normalize: bool = True
     timeout_secs: Annotated[int, Field(alias="timeoutSecs", ge=3, le=30)] = settings.FEED_TIMEOUT_SECS
     session_id: Annotated[str, Field(alias="sessionId")] = None
+    channels: Annotate[list[str], Field(alias="channels")] = None
 
 class SearchScores(BaseModel):
     score_type: Annotated[Literal['search'], Field(alias="scoreType")]

--- a/serve/app/routers/cast_router.py
+++ b/serve/app/routers/cast_router.py
@@ -76,9 +76,13 @@ async def get_popular_casts_for_fid(
             logger.error(f"errors(): {e.errors()}")
             raise HTTPException(status_code=400, detail=f"Error while validating provider metadata: {e.errors()}")
 
-        channel_ids = await db_utils.get_channel_ids_for_fid(
-            fid=fid, limit=settings.MAX_CHANNELS_PER_USER, pool=pool
-        )
+        if metadata.channels is not None:
+            # TODO(ek): validate channel IDs?
+            channel_ids = [{'channel_id': ch} for ch in metadata.channels]
+        else:
+            channel_ids = await db_utils.get_channel_ids_for_fid(
+                fid=fid, limit=settings.MAX_CHANNELS_PER_USER, pool=pool
+            )
         logger.info(f"channel_ids: {channel_ids}")
         if len(channel_ids) == 0:
             logger.info(f"No channels found for fid: {fid}")


### PR DESCRIPTION
When the metadata has a list of channel IDs in "channels" attribute, fetch casts from them instead of the channels followed by the FID.