### PR TITLE
bugfix: Polaris panics as it is unable to identify data type

### DIFF
--- a/pipeline/graph/gen_personal_graph_amp_v1.py
+++ b/pipeline/graph/gen_personal_graph_amp_v1.py
@@ -128,7 +128,14 @@ def process_slice(
     logger.debug(f"{process_label}{len(results)} results available")
 
     pl_slice = pl.LazyFrame(
-        results, schema={"fid": pl.UInt32, "degree": pl.UInt8, "scores": pl.List}
+        results,
+        schema={
+            "fid": pl.UInt32,
+            "degree": pl.UInt8,
+            "scores": pl.List(
+                pl.Struct([pl.Field("i", pl.UInt32), pl.Field("v", pl.Float32)])
+            ),
+        },
     )
 
     logger.debug(f"{process_label}pl_slice: {pl_slice.describe()}")


### PR DESCRIPTION
For one FID, the compute_task function generates a list of scores, like `[{'i': 123, 'v': 0.5}, {'i': 456, 'v': 0.4}]`.
For another FID, the compute_task generates an empty list [].

When polars tries to build the DataFrame, it infers the type of the scores column from the first row as 
`List[Struct(i: int, v: float)]`. But when it encounters the empty list, it can't determine the inner type, leading to a type mismatch and a crash.