### PR TITLE
fix[pipeline]: use float64 for personalized scores

### DIFF
--- a/pipeline/graph/gen_personal_graph_amp_v1.py
+++ b/pipeline/graph/gen_personal_graph_amp_v1.py
@@ -132,7 +132,7 @@ def process_slice(
                 "fid": pl.UInt32,
                 "degree": pl.UInt8,
                 "scores": pl.List(
-                    pl.Struct([pl.Field("i", pl.UInt32), pl.Field("v", pl.Float32)])
+                    pl.Struct([pl.Field("i", pl.UInt32), pl.Field("v", pl.Float64)])
                 ),
             },
         )


### PR DESCRIPTION
#121 introduced explicit types (instead of inferring types from values) for personalized score frames.  It used `Float32` as the score type whereas it should have used `Float64` to match what go-eigentrust outputs.

Spotted-by: singhbharath03